### PR TITLE
Security 2021-03, CVE-2019-10913, CVE-2019-10910, CVE-2019-10909

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/browser-kit": "^2.7 || ^3.0",
         "symfony/config": "^2.8 || ^3.0",
-        "symfony/dependency-injection": "^2.7 || ^3.4",
+        "symfony/dependency-injection": "^2.8 || ^3.4",
         "symfony/framework-bundle": "^2.7 || ^3.4",
         "symfony/http-kernel": "^2.7 || ^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": "^7.0",
-        "symfony/http-foundation": "^2.8 || ^3.4"
+        "symfony/http-foundation": "^2.7 || ^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.0",
@@ -24,8 +24,8 @@
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/browser-kit": "^2.7 || ^3.0",
         "symfony/config": "^2.8 || ^3.0",
-        "symfony/dependency-injection": "^2.8 || ^3.0",
-        "symfony/framework-bundle": "^2.7 || ^3.0",
+        "symfony/dependency-injection": "^2.7 || ^3.4",
+        "symfony/framework-bundle": "^2.7 || ^3.4",
         "symfony/http-kernel": "^2.7 || ^3.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": "^7.0",
-        "symfony/http-foundation": "^2.7 || ^3.0"
+        "symfony/http-foundation": "^2.8 || ^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.0",


### PR DESCRIPTION
looking at the advisories and the behaviour of composer's caret (^) ping-php *should* be covered, but I bumped the `3.0` to `3.4` just in case.